### PR TITLE
FIix:Uglifierについての記述をコメントアウト

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# What
config.assets.js_compressor = :uglifierをコメントアウトした。

# Why
uglifierはJavaScriptを軽量化するためのものだが、JavaScriptで使用するテンプレートリテラル記法（`）に対応していないので、デプロイ時にエラーの原因になる可能性があるため。