### PR TITLE
Fix:unicorn.rbを修正

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -6,7 +6,7 @@ working_directory app_path
 
 pid "#{app_path}/tmp/pids/unicorn.pid"
 
-listen 3000
+listen "#{app_path}/tmp/sockets/unicorn.sock"
 
 stderr_path "#{app_path}/log/unicorn.stderr.log"
 


### PR DESCRIPTION
# What
listen 3000
↓以下のように修正
listen "#{app_path}/tmp/sockets/unicorn.sock"

# Why
Nginxを介した処理を行うため。