### PR TITLE
Fix: config.public_file_server.enabledをtrueに設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   # config.assets.js_compressor = :uglifier


### PR DESCRIPTION
# What
config/production.rbのconfig.public_file_server.enabledをtrueに設定した。

# Why
production環境でcssやjsやimageがassets:precompileしてもnot foundになるため。