### PR TITLE
Fix: 投稿詳細ページのルーティングを修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
   get 'posts/display', to: 'posts#display'
   get 'posts/search', to: 'posts#search'
   get 'posts/new', to: 'posts#new'
-  get 'posts/show', to: 'posts#show'
+  get 'posts/:id', to: 'posts#show'
   get 'users/index', to: 'users#index'
 end


### PR DESCRIPTION
# What
投稿詳細ページのパスがposts/showになっていたのでposts/:idに修正した。

# Why
本番環境エラーに起因する可能性があるため。