### PR TITLE
Add: 本番環境でエラー画面を表示するように設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ group :development do
   #自動デプロイ用gem
   gem 'ed25519'
   gem 'bcrypt_pbkdf'
+  #デバック関係
+  gem 'binding_of_caller'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     bcrypt (3.1.13)
     bcrypt_pbkdf (1.0.1)
     bindex (0.8.1)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     bootstrap (4.1.3)
@@ -99,6 +101,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.5)
+    debug_inspector (0.0.3)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -339,6 +342,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt_pbkdf
+  binding_of_caller
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.1.1)
   byebug

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]


### PR DESCRIPTION
# What
gem 'binding_of_caller'を導入し、本番環境でエラー画面を表示するように設定した。

# Why
本番環境のエラーを特定しやすくするため。