### PR TITLE
Fix: capistranoで自動デプロイ時にワーニングが出るようになったので対応

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -3,6 +3,8 @@ require "capistrano/setup"
 
 # Include default deployment tasks
 require "capistrano/deploy"
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
 
 require 'capistrano/rbenv'
 require 'capistrano/bundler'


### PR DESCRIPTION
# What
capistranoで自動デプロイ時にワーニングが出るようになったので対応した。

# Why
ワーニングの内容通りCapfileのrequire "capistrano/deploy" の後に、
+require 'capistrano/scm/git'
+install_plugin Capistrano::SCM::Git
追記した。