### PR TITLE
Make: 【サーバーサイド】投稿一覧表示

### DIFF
--- a/app/assets/stylesheets/modules/_display.scss
+++ b/app/assets/stylesheets/modules/_display.scss
@@ -22,44 +22,47 @@
       display: grid;
       grid-template-columns: repeat(4, 1fr);
       gap: 20px 20px; 
-      .thumbnail {
-        background-color: #000;
-        border: none;
-        box-shadow: 0 0 6px #333;
-        border-radius: 4px;
-        padding: 4px;
-        display: block;
-        height: auto;
-        max-width: 100%;
-        padding: 4px;
-        .card-top {
-          position: relative;
-          max-width: 267px;
-          height: 177px;
-          overflow: hidden;
-          &__img {
-            position: absolute;
-            left: -100%;
-            top: -100%;
-            bottom: -100%;
-            right: -100%;
+      .show-link {
+        text-decoration: none;
+        .thumbnail {
+          background-color: #000;
+          border: none;
+          box-shadow: 0 0 6px #333;
+          border-radius: 4px;
+          padding: 4px;
+          display: block;
+          height: auto;
+          max-width: 100%;
+          padding: 4px;
+          .card-top {
+            position: relative;
             max-width: 267px;
-            margin: auto;
+            height: 177px;
+            overflow: hidden;
+            &__img {
+              position: absolute;
+              left: -100%;
+              top: -100%;
+              bottom: -100%;
+              right: -100%;
+              max-width: 267px;
+              margin: auto;
+            }
           }
-        }
-        .card-body {
-          color: #ccc;
-          padding: 9px;
-          .card-title {
-            margin-top: 0;
-            margin-bottom: 5px;
-          }
-          .card-user {
-            padding-bottom: 10px;
-            border-bottom: 1px solid #333;
-          }
-          p {
-            margin-bottom: 10px;
+          .card-body {
+            color: #ccc;
+            padding: 9px;
+            .card-title {
+              margin-top: 0;
+              margin-bottom: 5px;
+            }
+            .card-user {
+              padding-bottom: 10px;
+              border-bottom: 1px solid #333;
+            }
+            p {
+              margin-bottom: 10px;
+            }
           }
         }
       }

--- a/app/assets/stylesheets/modules/_footer.scss
+++ b/app/assets/stylesheets/modules/_footer.scss
@@ -6,5 +6,9 @@ footer {
   line-height: 10vh;
   p {
     margin: 0;
+    .footer-logo {
+      text-decoration: none;
+      color: #fff;
+    }
   }
 } 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,7 @@ class PostsController < ApplicationController
   end
 
   def display
-    @posts = Post.all
+    @posts = Post.all.order('id DESC').limit(24)
   end
 
   def search

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,6 +2,7 @@ class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :display, :search, :show]
 
   def index
+    @posts = Post.all
   end
 
   def display

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,7 @@ class PostsController < ApplicationController
   end
 
   def display
-    @posts = Post.all.order('id DESC').limit(24)
+    @posts = Post.order('id DESC').limit(24)
   end
 
   def search

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,10 +2,10 @@ class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :display, :search, :show]
 
   def index
-    @posts = Post.all
   end
 
   def display
+    @posts = Post.all
   end
 
   def search

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,7 @@ class PostsController < ApplicationController
   end
 
   def display
-    @posts = Post.order('id DESC').limit(24)
+    @posts = Post.order('id DESC').limit(24).includes(:user)
   end
 
   def search

--- a/app/views/posts/_post-list.html.haml
+++ b/app/views/posts/_post-list.html.haml
@@ -1,9 +1,12 @@
-.card.h-100.thumbnail
-  .card-top
-    = image_tag('first_slide.jpg', class: "card-top__img", alt: "First slide")
-  .card-body
-    %h5.card-title Card title
-    %p.card-user test-user
-    .text-right
-      = fa_icon 'star', class: 'icon'
-      %span 0
+= link_to post_path(post), class: "show-link" do
+  .card.h-100.thumbnail
+    .card-top
+      = image_tag post.image.url, class: 'card-top__img'
+    .card-body
+      %h5.card-title
+        = post.name
+      %p.card-user
+        = post.user.nickname
+      .text-right
+        = fa_icon 'star', class: 'icon'
+        %span 0

--- a/app/views/posts/_post-list.html.haml
+++ b/app/views/posts/_post-list.html.haml
@@ -1,0 +1,9 @@
+.card.h-100.thumbnail
+  .card-top
+    = image_tag('first_slide.jpg', class: "card-top__img", alt: "First slide")
+  .card-body
+    %h5.card-title Card title
+    %p.card-user test-user
+    .text-right
+      = fa_icon 'star', class: 'icon'
+      %span 0

--- a/app/views/posts/display.html.haml
+++ b/app/views/posts/display.html.haml
@@ -4,6 +4,7 @@
     .head__text 全ての投稿
   .main
     .posts-container
+      = render partial: 'posts/post-list'
       .card.h-100.thumbnail
         .card-top
           = image_tag('first_slide.jpg', class: "card-top__img", alt: "First slide")

--- a/app/views/posts/display.html.haml
+++ b/app/views/posts/display.html.haml
@@ -5,50 +5,5 @@
   .main
     .posts-container
       = render partial: 'posts/post-list', collection: @posts, as: "post"
-      .card.h-100.thumbnail
-        .card-top
-          = image_tag('first_slide.jpg', class: "card-top__img", alt: "First slide")
-        .card-body
-          %h5.card-title Card title
-          %p.card-user test-user
-          .text-right
-            = fa_icon 'star', class: 'icon'
-            %span 0
-      .card.h-100.thumbnail
-        .card-top
-          = image_tag('second_slide.jpg', class: "card-top__img", alt: "second_slide")
-        .card-body
-          %h5.card-title Card title
-          %p.card-user test-user
-          .text-right
-            = fa_icon 'star', class: 'icon'
-            %span 0
-      .card.h-100.thumbnail
-        .card-top
-          = image_tag('third_slide.jpg', class: "card-top__img", alt: "third_slide")
-        .card-body
-          %h5.card-title Card title
-          %p.card-user test-user
-          .text-right
-            = fa_icon 'star', class: 'icon'
-            %span 0
-      .card.h-100.thumbnail
-        .card-top
-          = image_tag('first_sample.jpg', class: "card-top__img", alt: "first_sample")
-        .card-body
-          %h5.card-title Card title
-          %p.card-user test-user
-          .text-right
-            = fa_icon 'star', class: 'icon'
-            %span 0
-      .card.h-100.thumbnail
-        .card-top
-          = image_tag('second_sample.jpg', class: "card-top__img", alt: "second_sample")
-        .card-body
-          %h5.card-title Card title
-          %p.card-user test-user
-          .text-right
-            = fa_icon 'star', class: 'icon-star'
-            %span 0
 
   = render "shared/footer"

--- a/app/views/posts/display.html.haml
+++ b/app/views/posts/display.html.haml
@@ -4,7 +4,7 @@
     .head__text 全ての投稿
   .main
     .posts-container
-      = render partial: 'posts/post-list'
+      = render partial: 'posts/post-list', :collection => @posts, :as => "post"
       .card.h-100.thumbnail
         .card-top
           = image_tag('first_slide.jpg', class: "card-top__img", alt: "First slide")

--- a/app/views/posts/display.html.haml
+++ b/app/views/posts/display.html.haml
@@ -4,7 +4,7 @@
     .head__text 全ての投稿
   .main
     .posts-container
-      = render partial: 'posts/post-list', :collection => @posts, :as => "post"
+      = render partial: 'posts/post-list', collection: @posts, as: "post"
       .card.h-100.thumbnail
         .card-top
           = image_tag('first_slide.jpg', class: "card-top__img", alt: "First slide")

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,3 +1,3 @@
 %footer{style: "background: rgb(0, 0, 0);"}
   %p
-    © 2019 AnimeMap
+    = link_to "© 2020 AnimeMap", root_path, class: "footer-logo"

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -1,5 +1,5 @@
 %nav.sticky-top.navbar.navbar-expand-lg.navbar-dark.header{style: "background-color: rgb(0, 0, 0, 0.5);"}
-  %a.navbar-brand{href: "#"} AnimeMap
+  = link_to "AnimeMap", root_path, class: "navbar-brand"
   .navbar-collapse.collapse.w-100.order-3.dual-collapse2
     %ul.navbar-nav.ml-auto
       %li.nav-item


### PR DESCRIPTION
# What
投稿を一覧表示する機能を追加した。
- renderメソッドを用いて一つの投稿項目をテンプレート化、それを繰り返し表示することで一覧を表示する。
- each文の代わりに、collectionオプションを用いて@postsの要素の数だけ部分テンプレートが繰り返されるように設定した。
- asオプションを用いてローカル変数を別の名前で使用した。

# Why
投稿を確認するため。
気になる投稿の詳細ページを表示する中継ページの役割あり。

# Preview
![post-display_function](https://user-images.githubusercontent.com/52768993/72310283-b5371f80-36c4-11ea-9cd7-c16dad5c8dc7.jpg)
