### PR TITLE
Make: 【サーバーサイド】投稿詳細ページ

### DIFF
--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -30,6 +30,7 @@
         border-top-right-radius: 3px;
         border-top-left-radius: 3px;
         display: flex;
+        position: relative;
         .title {
           font-size: 24px;
           margin: 10px 0;
@@ -65,13 +66,26 @@
         }
         .post-details {
           padding-top: 20px;
-          .post-details__anime-title {
+          &__anime-title {
             margin: 0 0 5px;
             font-size: 14px;
           }
-          .post-details__place {
+          &__place {
             margin: 0 0 10px;
             font-size: 14px;
+          }
+        }
+        .post-option {
+          position: absolute;
+          right: 0;
+          bottom: 0;
+          .edit-link {
+            text-decoration: none;
+            .btn {
+            }
+          }
+          .delete-link {
+            text-decoration: none;
           }
         }
       }

--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -55,8 +55,7 @@
             padding-left: 15px;
             &__user-name {
               font-size: 18px;
-              margin-top: 10px;
-              margin-bottom: 10px;
+              margin: 10px 0;
             }
             &__date {
               margin: 0 0 10px;
@@ -81,8 +80,6 @@
           bottom: 0;
           .edit-link {
             text-decoration: none;
-            .btn {
-            }
           }
           .delete-link {
             text-decoration: none;

--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -73,18 +73,27 @@
             margin: 0 0 10px;
             font-size: 14px;
           }
-          .post-details__description {
-            margin: 0 0 10px;
-            font-size: 14px;
-          }
         }
       }
-      &__map {
-        &__details {
-          .img-responsive {
-            display: block;
-            height: auto;
-            max-width: 100%;
+      &__middle {
+        color: #333333;
+        background-color: white;
+        border-color: #dddddd;
+        padding: 10px 15px;
+        border-bottom: 1px solid transparent;
+        display: flex;
+        &__left {
+          &__description {
+            font-size: 20px;
+          }
+        }
+        &__right {
+          &__map {
+            .img-responsive {
+              display: block;
+              height: auto;
+              max-width: 100%;
+            }
           }
         }
       }

--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -97,6 +97,59 @@
           }
         }
       }
+      &__foot {
+        color: #333333;
+        background-color: #f5f5f5;
+        border-color: #dddddd;
+        padding: 10px 15px;
+        border-bottom: 1px solid transparent;
+        border-bottom-right-radius: 3px;
+        border-bottom-left-radius: 3px;
+        display: flex;
+        &__left {
+          .comment {
+            &__head {
+              padding-bottom: 9px;
+              margin: 20px 0 20px;
+              border-bottom: 1px solid #eeeeee;
+              display: flex;
+              .icon {
+                margin-right: 5px;
+              }
+            }
+            &__body {
+              margin-bottom: 20px;
+              background-color: #ffffff;
+              border: 1px solid transparent;
+              border-radius: 4px;
+              padding: 15px;
+              color: #333333;
+              background-color: white;
+              &__head {
+                margin: 0 0 10px;
+                display: table-cell;
+                vertical-align: middle;
+                
+                &__user {
+                  font-weight: bold;
+                  color: #006699;
+                  text-decoration: none;
+                  margin-right: 5px;
+                  display: inline-block;
+                  
+                }
+                &__time {
+                  font-size: 12px;
+                  display: inline-block;
+                }
+              }
+              &__text {
+                margin-top: 5px;
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,6 +25,7 @@ class PostsController < ApplicationController
   end
 
   def show
+    @post = Post.find(params[:id])
   end
 
   def mypage

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -22,6 +22,11 @@
               = "作品名: #{@post.anime_title}"
             .post-details__place
               = "場所: #{@post.place}"
+          .post-option
+            = link_to "#", class: "edit-link" do
+              %button.btn.btn-light{type: "button"} 編集する
+            = link_to "#", class: "delete-link" do
+              %button.btn.btn-light{type: "button"} 削除する
       .post-info__middle
         .post-info__middle__left.col-xs-12.col-sm-5.col-md-5.pb010
           .post-info__middle__left__description

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -29,4 +29,16 @@
         .post-info__middle__right.col-xs-12.col-sm-7.col-md-7.pb010
           .post-info__middle__right__map
             = image_tag('shirakawago_map.jpg', class: "img-responsive center-block", alt: "shirakawago map")
+      .post-info__foot
+        .post-info__foot__left.col-md-8
+          .comment
+            .comment__head
+              = fa_icon 'comment', class: 'icon'
+              この写真のコメント
+            .comment__body
+              .comment__body__head
+                .comment__body__head__user test
+                .comment__body__head__time 20200114
+              .comment__body__text aaaaaaaaaaaaaaaaa
+        .post-info__foot__right
   = render "shared/footer"

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -2,22 +2,28 @@
   = render "shared/header"
   .show-wrapper
     .main-photo
-      = image_tag('first_slide.jpg', class: "img-responsive center-block", alt: "First slide")
+      = image_tag @post.image.url, class: 'img-responsive center-block'
     .post-info
       .post-info__head
         .col-xs-12.col-sm-5.col-md-6.pb010
-          .title ひなみざわ
+          .title
+            = @post.name
           .user-info
             .user-info__img
               = image_tag('no_image.jpg', class: "img-thumbnail__display", alt: "no image")
             .user-info__details
-              .user-info__details__username test
-              .user-info__details__date 投稿日：2019年12月21日07時28分55秒
+              .user-info__details__username
+                = @post.user.nickname
+              .user-info__details__date
+                = "投稿日: #{@post.created_at}"
         .col-xs-12.col-sm-7.col-md-6
           .post-details
-            .post-details__anime-title 作品名：ひぐらしのなく頃に
-            .post-details__place 場所：白川郷
-            .post-details__description ひぐらしのなく頃にの聖地です。
+            .post-details__anime-title
+              = "作品名: #{@post.anime_title}"
+            .post-details__place
+              = "場所: #{@post.place}"
+            .post-details__description
+              = @post.description
       .post-info__map
         .post-info__map__details
           = image_tag('shirakawago_map.jpg', class: "img-responsive center-block", alt: "shirakawago map")

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -19,7 +19,7 @@
         .col-xs-12.col-sm-7.col-md-6
           .post-details
             .post-details__anime-title
-              = "作品名: #{@post.anime_title}"
+              = "作品名: 『#{@post.anime_title}』"
             .post-details__place
               = "場所: #{@post.place}"
           - if user_signed_in? && @post.user_id == current_user.id

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -22,11 +22,12 @@
               = "作品名: #{@post.anime_title}"
             .post-details__place
               = "場所: #{@post.place}"
-          .post-option
-            = link_to "#", class: "edit-link" do
-              %button.btn.btn-light{type: "button"} 編集する
-            = link_to "#", class: "delete-link" do
-              %button.btn.btn-light{type: "button"} 削除する
+          - if user_signed_in? && @post.user_id == current_user.id
+            .post-option
+              = link_to "#", class: "edit-link" do
+                %button.btn.btn-light{type: "button"} 編集する
+              = link_to "#", class: "delete-link" do
+                %button.btn.btn-light{type: "button"} 削除する
       .post-info__middle
         .post-info__middle__left.col-xs-12.col-sm-5.col-md-5.pb010
           .post-info__middle__left__description

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -22,9 +22,11 @@
               = "作品名: #{@post.anime_title}"
             .post-details__place
               = "場所: #{@post.place}"
-            .post-details__description
-              = @post.description
-      .post-info__map
-        .post-info__map__details
-          = image_tag('shirakawago_map.jpg', class: "img-responsive center-block", alt: "shirakawago map")
+      .post-info__middle
+        .post-info__middle__left.col-xs-12.col-sm-5.col-md-5.pb010
+          .post-info__middle__left__description
+            = @post.description
+        .post-info__middle__right.col-xs-12.col-sm-7.col-md-7.pb010
+          .post-info__middle__right__map
+            = image_tag('shirakawago_map.jpg', class: "img-responsive center-block", alt: "shirakawago map")
   = render "shared/footer"

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -15,7 +15,7 @@
               .user-info__details__username
                 = @post.user.nickname
               .user-info__details__date
-                = "投稿日: #{@post.created_at}"
+                = "投稿日: #{@post.created_at.strftime("%Y年%m月%d日 %H時%M分")}"
         .col-xs-12.col-sm-7.col-md-6
           .post-details
             .post-details__anime-title

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,7 @@ module AnimeMap
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
 
+    config.time_zone = 'Tokyo'
+
   end
 end


### PR DESCRIPTION
# What
投稿の詳細ページを実装する。
- 画像,名前,投稿したユーザーの名前,投稿時刻,作品タイトル,場所,説明を表示した。
- 投稿時刻を日本時間に設定した。
- 説明とgooglemapの位置を修正した。
- 投稿へのコメント機能を実装するためのビューを追加した(マークアップ)
- 投稿したユーザーにしか編集と削除ができないように設定した。

# Why
- 投稿の詳しい情報を確認するため。
- 投稿の編集および削除ページに移動できるようにするため。

# Preview
![post-show_function1](https://user-images.githubusercontent.com/52768993/72318159-db69b900-36de-11ea-9610-5b847c500e67.jpg)
<img width="1119" alt="post-show_function2" src="https://user-images.githubusercontent.com/52768993/72318174-e290c700-36de-11ea-814d-e76943b1a3bd.png">
