### PR TITLE
Fix: 【サーバーサイド】コメント機能修正

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
+
+  validates :text, presence: true
 end

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -38,14 +38,15 @@
       .post-info__foot
         .post-info__foot__left.col-md-8
           .comment
-            = form_with(model: [@post, @comment], local: true) do |f|
-              .comment__form
-                .comment__form__head
-                  = fa_icon 'edit', class: 'icon'
-                  この写真にコメントする
-                .comment__form__body
-                  = f.text_area :text, rows: "4", cols: 40, maxlength:1000, class: "comment__form__body__text-form form-control"
-                  = f.submit "コメントを投稿する", class: "comment__form__body__submit btn btn-danger"
+            - if user_signed_in?
+              = form_with(model: [@post, @comment], local: true) do |f|
+                .comment__form
+                  .comment__form__head
+                    = fa_icon 'edit', class: 'icon'
+                    この写真にコメントする
+                  .comment__form__body
+                    = f.text_area :text, rows: "4", cols: 40, maxlength:1000, class: "comment__form__body__text-form form-control"
+                    = f.submit "コメントを投稿する", class: "comment__form__body__submit btn btn-danger"
             .comment__head
               = fa_icon 'comment', class: 'icon'
               この写真のコメント


### PR DESCRIPTION
# What
- バリデーションの追加
- ログイン時のみにコメントができるように設定した。

# Why
- 空のコメントを防ぐため。
- ユーザー以外の利用を防ぐため。