### PR TITLE
Fix: 【サーバーサイド】いいね機能エラー解決

### DIFF
--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -22,17 +22,18 @@
               = "作品名: 『#{@post.anime_title}』"
             .post-details__place
               = "場所: #{@post.place}"
-          .post-likes
-            - if current_user.already_liked?(@post)
-              = button_to post_like_path(@post), {method: :delete, class: "btn btn-danger fav"} do
-                = fa_icon 'heart', class: 'icon-already'
-                .count
-                  #{@post.likes.count}
-            - else
-              = button_to post_likes_path(@post), {class: "btn btn-danger fav"} do
-                = fa_icon 'heart', class: 'icon'
-                .count
-                  #{@post.likes.count}
+          - if user_signed_in?
+            .post-likes
+              - if current_user.already_liked?(@post)
+                = button_to post_like_path(@post), {method: :delete, class: "btn btn-danger fav"} do
+                  = fa_icon 'heart', class: 'icon-already'
+                  .count
+                    #{@post.likes.count}
+              - else
+                = button_to post_likes_path(@post), {class: "btn btn-danger fav"} do
+                  = fa_icon 'heart', class: 'icon'
+                  .count
+                    #{@post.likes.count}
 
           - if user_signed_in? && @post.user_id == current_user.id
             .post-option


### PR DESCRIPTION
# What
いいね機能に関するエラーを解決した。
- ログインしていないユーザーが詳細ページに行くといいねボタンの条件分岐の部分でuser_idがないためエラーが出る。
- いいねボタンに- if user_signed_in?を設定することでログインしている状態でしかいいねボタンを表示しないように設定してエラーを回避した。

# Why
ログインしていない状態で投稿詳細ページを表示可能にするため。