### PR TITLE
Make: 【サーバーサイド】コメント機能の非同期通信

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,10 +10,10 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery3
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
 //= require_tree .
-//= require jquery3
 //= require popper
 //= require bootstrap-sprockets

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,0 +1,6 @@
+$(function(){
+  $('#new_comment').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+  })
+})

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -35,5 +35,8 @@ $(function(){
       $('.textbox').val('');
       $('.form__submit').prop('disabled', false);
     })
+    .fail(function(){
+      alert('error');
+    })
   })
 })

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,4 +1,22 @@
 $(function(){
+  function buildHTML(comment){
+    var comments = comment.text ? `${comment.text}` : "";
+    var text = comments.replace(/\n|\r\n|\r/g, '<br>');
+    var html = `<div class= "comment__body">
+                  <div class= "comment__body__head">
+                    <div class= "comment__body__head__user">
+                      ${comment.user_name}
+                    </div>
+                    <div class= "comment__body__head__time">
+                      ${comment.created_at}
+                    </div>
+                    <div class= "comment__body__text">
+                      ${text}
+                    </div>
+                  </div>
+                </div>`
+    return html;
+  }
   $('#new_comment').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -10,6 +28,12 @@ $(function(){
       dataType: 'json',
       processData: false,
       contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.comment').append(html);
+      $('.textbox').val('');
+      $('.form__submit').prop('disabled', false);
     })
   })
 })

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,43 +1,45 @@
-$(function(){
-  function buildHTML(comment){
-    var comments = comment.text ? `${comment.text}` : "";
-    var text = comments.replace(/\n|\r\n|\r/g, '<br>');
-    var html = `<div class= "comment__body">
-                  <div class= "comment__body__head">
-                    <div class= "comment__body__head__user">
-                      ${comment.user_name}
+$(document).on('turbolinks:load', function() {
+  $(function(){
+    function buildHTML(comment){
+      var comments = comment.text ? `${comment.text}` : "";
+      var text = comments.replace(/\n|\r\n|\r/g, '<br>');
+      var html = `<div class= "comment__body">
+                    <div class= "comment__body__head">
+                      <div class= "comment__body__head__user">
+                        ${comment.user_name}
+                      </div>
+                      <div class= "comment__body__head__time">
+                        ${comment.created_at}
+                      </div>
+                      <div class= "comment__body__text">
+                        ${text}
+                      </div>
                     </div>
-                    <div class= "comment__body__head__time">
-                      ${comment.created_at}
-                    </div>
-                    <div class= "comment__body__text">
-                      ${text}
-                    </div>
-                  </div>
-                </div>`
-    return html;
-  }
-  $('#new_comment').on('submit', function(e){
-    e.preventDefault();
-    var formData = new FormData(this);
-    var url = $(this).attr('action')
-    $.ajax({
-      url: url,
-      type: "POST",
-      data: formData,
-      dataType: 'json',
-      processData: false,
-      contentType: false
-    })
-    .done(function(data){
-      var html = buildHTML(data);
-      $('.comment').append(html);
-      $('.textbox').val('');
-      $('.form__submit').prop('disabled', false);
-    })
-    .fail(function(){
-      alert('error');
-      $('.form__submit').prop('disabled', false);
+                  </div>`
+      return html;
+    }
+    $('#new_comment').on('submit', function(e){
+      e.preventDefault();
+      var formData = new FormData(this);
+      var url = $(this).attr('action')
+      $.ajax({
+        url: url,
+        type: "POST",
+        data: formData,
+        dataType: 'json',
+        processData: false,
+        contentType: false
+      })
+      .done(function(data){
+        var html = buildHTML(data);
+        $('.comment').append(html);
+        $('.textbox').val('');
+        $('.form__submit').prop('disabled', false);
+      })
+      .fail(function(){
+        alert('error');
+        $('.form__submit').prop('disabled', false);
+      })
     })
   })
 })

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -2,5 +2,14 @@ $(function(){
   $('#new_comment').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
   })
 })

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -37,6 +37,7 @@ $(function(){
     })
     .fail(function(){
       alert('error');
+      $('.form__submit').prop('disabled', false);
     })
   })
 })

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,19 +1,27 @@
 class CommentsController < ApplicationController
   def create
-    @comment = Comment.new(comment_params)
-    @comment.user_id = current_user.id
-    if @comment.save
-      redirect_back(fallback_location: root_path)
-    else
-      redirect_back(fallback_location: root_path)
+    @comment = Comment.create(comment_params)
+    respond_to do |format|
+      format.html { redirect_to post_path(params[:post_id])  }
+      format.json
     end
   end
+
+  # def create
+  #   @comment = Comment.new(comment_params)
+  #   @comment.user_id = current_user.id
+  #   if @comment.save
+  #     redirect_back(fallback_location: root_path)
+  #   else
+  #     redirect_back(fallback_location: root_path)
+  #   end
+  # end
 
   private
   def comment_params
     params.require(:comment).permit(
       :text
     )
-    .merge(post_id: params[:post_id])
+    .merge(post_id: params[:post_id], user_id: current_user.id)
   end
 end

--- a/app/views/comments/create.json.jbuilder
+++ b/app/views/comments/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.text  @comment.text
+json.user_id  @comment.user.id
+json.user_name  @comment.user.nickname
+json.created_at  @comment.created_at.strftime("%Y年%m月%d日 %H時%M分")

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -52,14 +52,14 @@
         .post-info__foot__left.col-md-8
           .comment
             - if user_signed_in?
-              = form_with(model: [@post, @comment], local: true) do |f|
+              = form_with(model: [@post, @comment], local: true, id: "new_comment") do |f|
                 .comment__form
                   .comment__form__head
                     = fa_icon 'edit', class: 'icon'
                     この写真にコメントする
                   .comment__form__body
-                    = f.text_area :text, rows: "4", cols: 40, maxlength:1000, class: "comment__form__body__text-form form-control"
-                    = f.submit "コメントを投稿する", class: "comment__form__body__submit btn btn-danger"
+                    = f.text_area :text, rows: "4", cols: 40, maxlength:1000, class: "comment__form__body__text-form form-control textbox"
+                    = f.submit "コメントを投稿する", class: "comment__form__body__submit btn btn-danger form__submit"
             .comment__head
               = fa_icon 'comment', class: 'icon'
               この写真のコメント


### PR DESCRIPTION
# What
投稿詳細ページのコメント機能を非同期通信で実装する。
以下の点を工夫した。
- 非同期の状態でもコメントテキストの改行を反映させる。
- エラー後もsubmitボタンを押せるようにした。
- application.jsの記述順序を留意した。
- 遷移時にjsを効かすため`turbolinks:load`イベントをバインドした。

# Why
投稿にコメントをする都度ページを遷移せずにコメントができユーザビリティが向上につながるため。

# Preview
https://gyazo.com/f68350d9ab4512f23592b456c8cc3c72