### PR TITLE
Fix 【マークアップ】投稿一覧表示をレスポンシブデザインに修正

### DIFF
--- a/app/assets/stylesheets/modules/_display.scss
+++ b/app/assets/stylesheets/modules/_display.scss
@@ -20,8 +20,14 @@
     .posts-container {
       margin: 20px auto 20px;
       display: grid;
-      grid-template-columns: repeat(4, 1fr);
+      grid-template-columns: repeat(1, 1fr);
       gap: 20px 20px; 
+      @media screen and (min-width: 400px) {
+        grid-template-columns: repeat(2, 1fr);
+      }
+      @media screen and (min-width: 768px) {
+        grid-template-columns: repeat(4, 1fr);
+      } 
       .show-link {
         text-decoration: none;
         .thumbnail {

--- a/app/assets/stylesheets/modules/_display.scss
+++ b/app/assets/stylesheets/modules/_display.scss
@@ -9,8 +9,6 @@
     padding-bottom: 9px;
     margin: 0px 0 20px;
     border-bottom: 1px solid #eeeeee;
-    margin: 0 auto;
-    width: 90%;
     &__text {
       color: #fff;
       font-size: 30px;
@@ -20,7 +18,6 @@
   }
   .main {
     .posts-container {
-      width: 90%;
       margin: 20px auto 20px;
       display: grid;
       grid-template-columns: repeat(4, 1fr);

--- a/app/assets/stylesheets/modules/_mypage.scss
+++ b/app/assets/stylesheets/modules/_mypage.scss
@@ -96,10 +96,16 @@
     }
     .my-posts-main {
       .posts-container {
-        margin: 20px auto 20px;
+        margin: 50px auto 20px;
         display: grid;
-        grid-template-columns: repeat(4, 1fr);
-        gap: 20px 20px;
+        grid-template-columns: repeat(1, 1fr);
+        gap: 20px 20px; 
+        @media screen and (min-width: 400px) {
+          grid-template-columns: repeat(2, 1fr);
+        }
+        @media screen and (min-width: 768px) {
+          grid-template-columns: repeat(4, 1fr);
+        } 
         .show-link {
           text-decoration: none;
           .thumbnail {

--- a/app/assets/stylesheets/modules/_search.scss
+++ b/app/assets/stylesheets/modules/_search.scss
@@ -38,8 +38,14 @@
       padding-top: 25px;
       margin: 10px auto 20px;
       display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      gap: 20px 20px;
+      grid-template-columns: repeat(1, 1fr);
+      gap: 20px 20px; 
+      @media screen and (min-width: 400px) {
+        grid-template-columns: repeat(2, 1fr);
+      }
+      @media screen and (min-width: 768px) {
+        grid-template-columns: repeat(4, 1fr);
+      } 
       .show-link {
         text-decoration: none;
         .thumbnail {

--- a/app/assets/stylesheets/modules/_search.scss
+++ b/app/assets/stylesheets/modules/_search.scss
@@ -7,8 +7,6 @@
   flex-direction: column;
   .head {
     margin: 0px 0 0px;
-    margin: 0 auto;
-    width: 90%;
     display: flex;
     .bracket {
       color: #fff;
@@ -31,7 +29,6 @@
   }
   .new-posts {
     margin: 20px auto 10px;
-    width: 90%;
     color: #fff;
     font-size: 30px;
   }
@@ -39,7 +36,6 @@
     .posts-container {
       border-top: 1px solid #eeeeee;
       padding-top: 25px;
-      width: 90%;
       margin: 10px auto 20px;
       display: grid;
       grid-template-columns: repeat(4, 1fr);

--- a/app/assets/stylesheets/modules/_toppage.scss
+++ b/app/assets/stylesheets/modules/_toppage.scss
@@ -4,7 +4,6 @@
   margin-left: auto;
   .main {
     .posts-container {
-      width: 90%;
       margin: 50px auto 20px;
       display: grid;
       grid-template-columns: repeat(4, 1fr);

--- a/app/assets/stylesheets/modules/_toppage.scss
+++ b/app/assets/stylesheets/modules/_toppage.scss
@@ -6,8 +6,14 @@
     .posts-container {
       margin: 50px auto 20px;
       display: grid;
-      grid-template-columns: repeat(4, 1fr);
+      grid-template-columns: repeat(1, 1fr);
       gap: 20px 20px; 
+      @media screen and (min-width: 400px) {
+        grid-template-columns: repeat(2, 1fr);
+      }
+      @media screen and (min-width: 768px) {
+        grid-template-columns: repeat(4, 1fr);
+      } 
       .show-link {
         text-decoration: none;
         .thumbnail {

--- a/app/views/posts/display.html.haml
+++ b/app/views/posts/display.html.haml
@@ -1,10 +1,11 @@
 .display-warpper
   = render "shared/header"
-  .head
-    .head__text 全ての投稿
-  .main
-    .posts-container
-      = render partial: 'posts/post-list', collection: @posts, as: "post"
+  .container
+    .head
+      .head__text 全ての投稿
+    .main
+      .posts-container
+        = render partial: 'posts/post-list', collection: @posts, as: "post"
   = paginate @posts
 
   = render "shared/footer"

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -29,8 +29,9 @@
       %span.carousel-control-next-icon{aria:{hidden: "true"}}
       %span.sr-only Next
   .main
-    .posts-container
-      = render partial: 'posts/post-list', collection: @posts, as: "post"
+    .container
+      .posts-container
+        = render partial: 'posts/post-list', collection: @posts, as: "post"
 
   .jumbotron.jumbotron-fluid.information
     .container

--- a/app/views/posts/search.html.haml
+++ b/app/views/posts/search.html.haml
@@ -1,32 +1,35 @@
 .search-warpper
   = render "shared/header"
   - if params[:q][:name_or_anime_title_or_place_or_description_cont] == ""
-    .new-posts 新規投稿
-    .main
-      .posts-container
-        = render partial: 'posts/post-list', collection: @posts, as: "post"
+    .container
+      .new-posts 新規投稿
+      .main
+        .posts-container
+          = render partial: 'posts/post-list', collection: @posts, as: "post"
   - elsif @search_posts.present?
-    .head
-      .bracket 「
-      .search-keyword
-        = params[:q][:name_or_anime_title_or_place_or_description_cont]
-      .bracket 」
-      .head__text の検索結果
-    .main
-      .posts-container
-        = render partial: 'posts/post-list', collection: @search_posts, as: "post"
+    .container
+      .head
+        .bracket 「
+        .search-keyword
+          = params[:q][:name_or_anime_title_or_place_or_description_cont]
+        .bracket 」
+        .head__text の検索結果
+      .main
+        .posts-container
+          = render partial: 'posts/post-list', collection: @search_posts, as: "post"
     = paginate @search_posts
   - else
-    .head
-      .bracket 「
-      .search-keyword
-        = params[:q][:name_or_anime_title_or_place_or_description_cont]
-      .bracket 」
-      .head__text
-        に一致する投稿はありません。
-    .new-posts 新規投稿
-    .main
-      .posts-container
-        = render partial: 'posts/post-list', collection: @posts, as: "post"
+    .container
+      .head
+        .bracket 「
+        .search-keyword
+          = params[:q][:name_or_anime_title_or_place_or_description_cont]
+        .bracket 」
+        .head__text
+          に一致する投稿はありません。
+      .new-posts 新規投稿
+      .main
+        .posts-container
+          = render partial: 'posts/post-list', collection: @posts, as: "post"
 
   = render "shared/footer"

--- a/app/views/users/like.html.haml
+++ b/app/views/users/like.html.haml
@@ -1,10 +1,11 @@
 .display-warpper
   = render "shared/header"
-  .head
-    .head__text いいねした投稿
-  .main
-    .posts-container
-      = render partial: 'posts/post-list', collection: @posts, as: "post"
+  .container
+    .head
+      .head__text いいねした投稿
+    .main
+      .posts-container
+        = render partial: 'posts/post-list', collection: @posts, as: "post"
   = paginate @posts
 
   = render "shared/footer"


### PR DESCRIPTION
# What
投稿を一覧で表示する各ページをレスポンシブデザインにした。
- 大枠はbootstrapで設定。
- 一覧表示の箇所はマークアップの段階でCSSグリッドを用いていたのでそのままbootstrapを用いずに実装した。(こちらの方が細かい調整が可能なため)

# Why
画面のサイズに合わせてデザインを変更することでユーザビリティを向上するため。

# Preview
<img width="715" alt="responsive-design" src="https://user-images.githubusercontent.com/52768993/75158157-e2153280-5758-11ea-9a78-449ce05c1331.png">

